### PR TITLE
Provide means to configure a logfile

### DIFF
--- a/log.go
+++ b/log.go
@@ -5,34 +5,63 @@ import (
 
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/log15"
+	"path/filepath"
+	"fmt"
+	"github.com/pkg/errors"
 )
 
 var mainHandler log15.Handler
 var bypassHandler log15.Handler
 
 func init() {
-	resetWithLogLevel("debug")
+	ResetWithLogLevel("debug", "")
 }
 
+// TODO: srm - either enhance this with logDir or throw it out.
 func SetLogLevel(logLevel string) {
-	resetWithLogLevel(logLevel)
+	ResetWithLogLevel(logLevel, "")
 }
 
-func resetWithLogLevel(logLevel string) {
+func ResetWithLogLevel(logLevel string, logDir string) (error) {
 	// main handler
-	//handlers := []log15.Handler{}
+	handlers := []log15.Handler{}
 	mainHandler = log15.LvlFilterHandler(
 		getLevel(logLevel),
 		log15.StreamHandler(os.Stdout, log15.TerminalFormat()),
 	)
-	//handlers = append(handlers, mainHandler)
+	handlers = append(handlers, mainHandler)
+
+	// only provide a logfile if a path has been given. log to terminal anyway
+	if (logDir != "") {
+
+		var logFile = "node.log"
+
+		var absoluteLogPath, dirErr = filepath.Abs(logDir)
+		var absoluteLogFile, fileErr = filepath.Abs(logFile)
+
+		if fileErr != nil || dirErr != nil {
+			var err = Fmt("Given log_dir cannot be parsed [log_dir=%s]\n", logFile)
+			fmt.Println(err)
+			return errors.New(err)
+		}
+
+		if _, err := os.Stat(absoluteLogPath); err != nil {
+			var err = Fmt("The given log_dir does not exist [log_dir=%s]\n", absoluteLogPath)
+			fmt.Println(err)
+			return errors.New(err)
+		}
+
+		handlers = append(handlers, log15.Must.FileHandler(absoluteLogFile, log15.TerminalFormat()))
+	}
 
 	// bypass handler for not filtering on global logLevel.
 	bypassHandler = log15.StreamHandler(os.Stdout, log15.TerminalFormat())
 	//handlers = append(handlers, bypassHandler)
 
 	// By setting handlers on the root, we handle events from all loggers.
-	log15.Root().SetHandler(mainHandler)
+	log15.Root().SetHandler(handlers)
+
+	return nil
 }
 
 // See go-wire/log for an example of usage.


### PR DESCRIPTION
*THIS IS REQUIRED BY PR: https://github.com/tendermint/tendermint/pull/428*

- new config parameter "log_dir" in config.toml
- if not-set, logging will only happen to stdout
- if set, logging will be written to a file named "node.log", located in the given dir
- logging will _always_ happen on stdout, whether a log_dir is configured or not
- tendermint will not start if the given log_dir does not exist